### PR TITLE
removed imported firdes from yml and python template

### DIFF
--- a/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_eye_sink_x.block.yml
@@ -928,8 +928,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+
     callbacks:
     - set_time_domain_axis(${min}, ${max})
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_freq_sink_x.block.yml
@@ -405,8 +405,8 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})
@@ -466,7 +466,7 @@ templates:
         ${ gui_hint() % win}
 
 cpp_templates:
-    includes: ['#include <gnuradio/qtgui/${type.fcn}.h>', '#include <gnuradio/filter/firdes.h>']
+    includes: ['#include <gnuradio/qtgui/${type.fcn}.h>']
     declarations: 'qtgui::${type.fcn}::sptr ${id};'
     callbacks:
     - set_frequency_range(${fc}, ${bw})

--- a/gr-qtgui/grc/qtgui_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_sink_x.block.yml
@@ -111,7 +111,6 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
     callbacks:
     - set_frequency_range(${fc}, ${bw})
@@ -140,7 +139,7 @@ templates:
 
 
 cpp_templates:
-  includes: ['#include <gnuradio/qtgui/${type.fcn}.h>', '#include <gnuradio/filter/firdes.h>']
+  includes: ['#include <gnuradio/qtgui/${type.fcn}.h>']
   declarations: gr::qtgui::${type.fcn}::sptr ${id};
   make: |-
     <%

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml
@@ -998,8 +998,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+    
     callbacks:
     - set_update_time(${update_time})
     - set_y_axis(${ymin}, ${ymax})

--- a/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
+++ b/gr-qtgui/grc/qtgui_time_sink_x.block.yml.py
@@ -256,8 +256,8 @@ inputs:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+    
     callbacks:
     - set_time_domain_axis(${min}, ${max})
     - set_update_time(${update_time})

--- a/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
+++ b/gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
@@ -258,8 +258,8 @@ asserts:
 
 templates:
     imports: |-
-        from gnuradio.filter import firdes
         import sip
+        
     callbacks:
     - set_frequency_range(${fc}, ${bw})
     - set_update_time(${update_time})


### PR DESCRIPTION
## Description
Removed unused imported libraries that were copied in from the python yaml template genarator file.

## Related Issue
Fixes #6507

## Which blocks/areas does this affect?
gr-qtgui/grc/qtgui_eye_sink_x.block.yml
gr-qtgui/grc/qtgui_freq_sink_x.block.yml
gr-qtgui/grc/qtgui_sink_x.block.yml
gr-qtgui/grc/qtgui_time_sink_x.block.yml
gr-qtgui/grc/qtgui_waterfall_sink_x.block.yml
gr-qtgui/grc/qtgui_time_sink_x.block.yml.py

## Testing Done
Tested all yaml files in validator to ensure no syntax errors and also reviewed all the files to make sure the libraries that were removed were not being used anywhere.

## Checklist
<!--- Go over all the following points, and put an `x` in all the
<!--- boxes that apply. Note that some of these may not be valid -->
<!--- for all PRs. -->

- [x] I have read the [CONTRIBUTING document](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md).
- [x] I have squashed my commits to have one significant change per commit. 
- [x] I [have signed my commits before making this PR](https://github.com/gnuradio/gnuradio/blob/main/CONTRIBUTING.md#dco-signed)
- [x] My code follows the code style of this project. See [GREP1.md](https://github.com/gnuradio/greps/blob/main/grep-0001-coding-guidelines.md).
- [x] I have updated [the documentation](https://wiki.gnuradio.org/index.php/Main_Page#Documentation) where necessary.
- [x] I have added tests to cover my changes, and all previous tests pass.
